### PR TITLE
fix(exit): correct exit codes for non-error ops

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -130,12 +130,12 @@ fn rocket_main() -> _ {
 
     if matches.opt_present("v") {
         println!("Version: {}, revision: {}", CARGO_VERSION, VERSION);
-        exit(1);
+        exit(0);
     }
 
     if matches.opt_present("h") {
         print_usage(&program, opts);
-        exit(1);
+        exit(0);
     }
 
     let server_configuration = ServerConfiguration {


### PR DESCRIPTION
## What problem are you trying to solve?

Not sure why we are exiting with 1 in some valid use cases. I found this while integrating the server into VS Code. The exit code made the commands receive an error.

## What is your solution?

Changed exit to 0 to avoid node errors when spawing the process.

## Alternatives considered

For what I can see, there are other places in the codebase that could potentially run into the same kind of issues. Nonetheless, I've focused this PR into the IDE related codebase.

## What the reviewer should know




IDE-1596
